### PR TITLE
Update winget packages to 0.23.1

### DIFF
--- a/manifests/h/Headlamp/Headlamp/0.23.1/Headlamp.Headlamp.installer.yaml
+++ b/manifests/h/Headlamp/Headlamp/0.23.1/Headlamp.Headlamp.installer.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: Headlamp.Headlamp
+PackageVersion: 0.23.1
+Installers:
+  - Architecture: x64
+    InstallerLocale: en-US
+    InstallerType: exe
+    InstallerUrl: https://github.com/headlamp-k8s/headlamp/releases/download/v0.23.1/Headlamp-0.23.1-win-x64.exe
+    InstallerSha256: 2bea7b15597fdd20ba6d2fed28f3626a9b625121369658b97016b71c10ab93b6
+    Scope: user
+    InstallModes:
+      - interactive
+      - silent
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+    AppsAndFeaturesEntries:
+      - DisplayName: Headlamp
+        DisplayVersion: 0.23.1
+        Publisher: Headlamp
+        InstallerType: exe
+    ReleaseDate: 2024-03-27
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/h/Headlamp/Headlamp/0.23.1/Headlamp.Headlamp.locale.en-US.yaml
+++ b/manifests/h/Headlamp/Headlamp/0.23.1/Headlamp.Headlamp.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: Headlamp.Headlamp
+PackageVersion: 0.23.1
+PackageLocale: en-US
+Publisher: Headlamp
+PublisherUrl: https://headlamp.dev
+PackageName: Headlamp
+License: Apache 2.0
+LicenseUrl: https://github.com/headlamp-k8s/headlamp/blob/main/LICENSE
+ShortDescription: Kubernetes web UI.
+Description: A Kubernetes web UI that is fully-featured, user-friendly and extensible.
+Tags:
+  - kubernetes
+  - plugins
+  - kinvolk
+  - headlamp
+  - dashboard
+  - ui
+  - web
+  - monitoring
+  - logging
+  - cncf
+Documentations:
+  - DocumentLabel: headlamp documentation
+    DocumentUrl: https://headlamp.dev/docs/latest
+ReleaseNotesUrl: https://github.com/headlamp-k8s/headlamp/releases/tag/v0.23.1
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/h/Headlamp/Headlamp/0.23.1/Headlamp.Headlamp.yaml
+++ b/manifests/h/Headlamp/Headlamp/0.23.1/Headlamp.Headlamp.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Headlamp.Headlamp
+PackageVersion: 0.23.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
This PR updates the winget packages to the Headlamp project to version 0.23.1